### PR TITLE
Remove the Emacs Lisp specific escaping test.

### DIFF
--- a/rainbow-delimiters-test.el
+++ b/rainbow-delimiters-test.el
@@ -194,17 +194,17 @@
 
 (ert-deftest doesnt-highlight-escaped-delimiters ()
   (with-temp-buffer-in-mode 'emacs-lisp-mode
-    (with-string (str "(bar ?\\( ?( (foo?))")
+    (with-string (str "(bar ?\\( (foo?))")
       (should (ert-equal-including-properties
                (buffer-string)
-               #("(bar ?\\( ?( (foo?))"
+               #("(bar ?\\( (foo?))"
                  0 1
                  (face (rainbow-delimiters-depth-1-face))
-                 12 13
+                 9 10
                  (face (rainbow-delimiters-depth-2-face))
-                 17 18
+                 14 15
                  (face (rainbow-delimiters-depth-2-face))
-                 18 19
+                 15 16
                  (face (rainbow-delimiters-depth-1-face))))))))
 
 (ert-deftest cycles-faces ()

--- a/rainbow-delimiters.el
+++ b/rainbow-delimiters.el
@@ -184,27 +184,6 @@ The delimiter is not highlighted if it's a blacklisted delimiter."
                         (rainbow-delimiters--depth-face depth)))))
       (font-lock-prepend-text-property loc (1+ loc) 'face delim-face))))
 
-(defvar rainbow-delimiters-escaped-char-predicate nil)
-(make-variable-buffer-local 'rainbow-delimiters-escaped-char-predicate)
-
-(defvar rainbow-delimiters-escaped-char-predicate-list
-  '((emacs-lisp-mode . rainbow-delimiters--escaped-char-predicate-emacs-lisp)
-    (lisp-interaction-mode . rainbow-delimiters--escaped-char-predicate-emacs-lisp)
-    (inferior-emacs-lisp-mode . rainbow-delimiters--escaped-char-predicate-emacs-lisp)
-    ))
-
-(defun rainbow-delimiters--escaped-char-predicate-emacs-lisp (loc)
-  "Non-nil iff the character at LOC is escaped as per Emacs Lisp rules."
-  (and (eq (char-before loc) ?\?) ; e.g. ?) - deprecated, but people use it
-       (not (and (eq (char-before (1- loc)) ?\\) ; special case: ignore ?\?
-                 (eq (char-before (- loc 2)) ?\?)))
-       ;; Treat the ? as a quote character only when it starts a symbol, so
-       ;; we're not confused by (foo?), which is a valid function call.
-       (let ((inhibit-changing-match-data t))
-         (save-excursion
-           (goto-char (1- loc))
-           (looking-at "\\_<")))))
-
 (defun rainbow-delimiters--char-ineligible-p (loc ppss delim-syntax-code)
   "Return t if char at LOC should not be highlighted.
 PPSS is the `parse-partial-sexp' state at LOC.
@@ -228,9 +207,7 @@ Returns t if char at loc meets one of the following conditions:
     ((/= 0 (logand #x20000 delim-syntax-code))
      (/= 0 (logand #x10000 (or (car (syntax-after (1- loc))) 0))))
     (t
-     nil))
-   (when rainbow-delimiters-escaped-char-predicate
-     (funcall rainbow-delimiters-escaped-char-predicate loc))))
+     nil))))
 
 (defconst rainbow-delimiters--delim-regex "\\s(\\|\\s)"
   "Regex matching all opening and closing delimiters the mode highlights.")
@@ -240,8 +217,6 @@ Returns t if char at loc meets one of the following conditions:
   "Highlight delimiters in region between point and END.
 
 Used by font-lock for dynamic highlighting."
-  (setq rainbow-delimiters-escaped-char-predicate
-        (cdr (assoc major-mode rainbow-delimiters-escaped-char-predicate-list)))
   (let* ((inhibit-point-motion-hooks t)
          ;; Point can be anywhere in buffer; determine the nesting depth at point.
          (last-ppss-pos (point))


### PR DESCRIPTION
In fact, nuke the infrastructure altogether.

Parens as characters without a backslash are nasty and they really should never be used:
- This syntax is discouraged by the GNU Emacs Lisp Reference Manual.
- They confuse many a minor mode, such as `show-paren-mode`.
- The way we currently handle them partially solves the problem, but is a hack made of eldritch magic, implemented by gluing special cases together hoping they'll work...
- ...but it doesn't really work, and it's pretty easy to get mishighlighted delimiters anyway.
- They confuse the Emacs Lisp indentation engine. Really.
- It's the major mode's job to set the `syntax-table` properties on individual characters.

Because of these reasons, it's just easier to drop this misfeature and rely on people to start using `?\(` instead.

And because the whole point of `rainbow-delimiters-escaped-char-predicate-list` is to allow for this, nuke it too. It was never _really_ a documented part of the API.

---

@purcell (and others who want this test still there): I'm sorry. I understand that you want it. But the current hack doesn't really work. Try deleting the backslash in this code:

``` emacs-lisp
(lorem '(?\[ ipsum))

(defun lorem (ipsum)
  (dolor)
  (sit amet))
```

The `)` closing the list will be mismatched, and everything below and including the `defun` will have wrong depth.

If you want to have a _truly working_ handling of unbackslashed parens as characters, you should probably try and contribute to the `EVIL-ignore-blacklisted-delims-altogether` branch. The approach used there has at least _some_ chance of getting this right, for some values of "right".

Or, convince me that the broken mess used by rainbow-delimiters right now is better than a similarly broken non-mess. To be frank, I suggest you invest your time into making #1 mergable instead of trying to convince me, as it's much easier.
