### PR TITLE
add deprecation section mentioning global mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,8 @@ You can specify custom colors by customizing following faces:
    depth. Depth begins at 1, the outermost color. Faces exist for depths 1-9.
  * The unmatched delimiter face: `rainbow-delimiters-unmatched-face`.
  * The mismatched delimiter face: `rainbow-delimiters-mismatched-face`.
+
+## Deprecations
+
+The edior-wide `(global-rainbow-delimiters-mode)` is no longer supported.
+


### PR DESCRIPTION
Hey, I just wanted to say thanks for maintaining this very cool repo. The reason I'd like to see this change in the readme is that several top-hits for a google search of rainbow-delimiters have example code showing the global mode in use. I wasn't able to find out it was deprecated until I searched around for a while, and as an emacs n00b it was hard to figure out if there was a deprecation or if I was doing something wrong. Hopefully having a section for deprecations will save other folks some time. Thanks again!