### PR TITLE
Inherit all rainbow-delimiters faces from a base face

### DIFF
--- a/rainbow-delimiters.el
+++ b/rainbow-delimiters.el
@@ -104,14 +104,20 @@ The function should not move the point or mark or change the match data."
   :type 'function
   :group 'rainbow-delimiters)
 
+(defface rainbow-delimiters-base-face
+  '((default (:inherit unspecified)))
+  "Face inherited by all other rainbow-delimiter faces."
+  :group 'rainbow-delimiters-faces)
+
 (defface rainbow-delimiters-unmatched-face
-  '((((background light)) (:foreground "#88090B"))
-    (((background dark)) (:foreground "#88090B")))
+  '((default (:inherit rainbow-delimiters-base-face))
+    (((background light)) (:foreground "#88090B"))
+    (((background dark)) (:inherit rainbow-delimiters-base-face :foreground "#88090B")))
   "Face to highlight unmatched closing delimiters in."
   :group 'rainbow-delimiters-faces)
 
 (defface rainbow-delimiters-mismatched-face
-  '((t :inherit rainbow-delimiters-unmatched-face))
+  '((t :inherit (rainbow-delimiters-unmatched-face rainbow-delimiters-base-face)))
   "Face to highlight mismatched closing delimiters in."
   :group 'rainbow-delimiters-faces)
 
@@ -124,7 +130,8 @@ The function should not move the point or mark or change the match data."
                         "#b0b0b3" "#90a890" "#a2b6da" "#9cb6ad"]))
       (dotimes (i 9)
         (push `(defface ,(intern (format "rainbow-delimiters-depth-%d-face" (1+ i)))
-                 '((((class color) (background light)) :foreground ,(aref light-colors i))
+                 '((default (:inherit rainbow-delimiters-base-face))
+                   (((class color) (background light)) :foreground ,(aref light-colors i))
                    (((class color) (background dark)) :foreground ,(aref dark-colors i)))
                  ,(format "Nested delimiter face, depth %d." (1+ i))
                  :group 'rainbow-delimiters-faces)


### PR DESCRIPTION
With a common base face it is possible for a user to set a face
attribute to all rainbow-delimiter faces by manipulating just
rainbow-delimiters-base-face.