### PR TITLE
Call widen before propertizing

### DIFF
--- a/rainbow-delimiters.el
+++ b/rainbow-delimiters.el
@@ -231,6 +231,7 @@ Returns t if char at loc meets one of the following conditions:
   "Highlight delimiters in region between point and END.
 
 Used by font-lock for dynamic highlighting."
+  (widen)
   (let* ((last-ppss-pos (point))
          (ppss (syntax-ppss)))
     (while (> end (progn (skip-syntax-forward "^()" end)


### PR DESCRIPTION
This is to ensure that delimiters are properly colored according to the whole buffer even if a portion of the buffer is narrowed. This came up for me because I am trying to get rainbow delimiters to work with mmm-mode. This simple fix seems to work just fine.