### PR TITLE
Remove new text property in the C++ template syntax test.

### DIFF
--- a/rainbow-delimiters-test.el
+++ b/rainbow-delimiters-test.el
@@ -147,7 +147,7 @@
       (should (ert-equal-including-properties
                (progn
                  (remove-list-of-text-properties
-                  (point-min) (point-max) '(category c-type syntax-table))
+                  (point-min) (point-max) '(category c-type c-<>-c-types-set syntax-table))
                  (buffer-string))
                #("foo<int> x;"
                  0 3 (face font-lock-type-face)


### PR DESCRIPTION
Fixes the following test error in Emacs 29:
```elisp
Running 24 tests (2023-08-29 02:40:33+0000, selector ‘t’)
   passed   1/24  can-customize-face-picker (0.000298 sec)
   passed   2/24  can-disable-mode (0.000057 sec)
   passed   3/24  can-enable-mode (0.000046 sec)
   passed   4/24  cycles-faces (0.000172 sec)
   passed   5/24  delimiters-disabled-by-face-picker-contribute-to-depth (0.000102 sec)
   passed   6/24  doesnt-cycle-outermost-only-faces (0.000142 sec)
   passed   7/24  doesnt-highlight-escaped-delimiters (0.000208 sec)
   passed   8/24  doesnt-highlight-in-comments-1 (0.000241 sec)
   passed   9/24  doesnt-highlight-in-comments-2 (0.001711 sec)
   passed  10/24  doesnt-highlight-in-strings (0.000255 sec)
   passed  11/24  doesnt-higlight-nondelimiters-1 (0.000088 sec)
   passed  12/24  doesnt-higlight-nondelimiters-2 (0.000222 sec)
   passed  13/24  face-picker-can-disable-highlighting (0.017793 sec)
Test highlights-all-delimiters backtrace:
  ert-fail(((should (ert-equal-including-properties (progn (remove-lis
  (if (unwind-protect (setq value-46 (apply fn-44 args-45)) (setq form
  (let (form-description-48) (if (unwind-protect (setq value-46 (apply
  (let ((value-46 'ert-form-evaluation-aborted-47)) (let (form-descrip
  (let* ((fn-44 #'ert-equal-including-properties) (args-45 (condition-
  (let ((str "foo<int> x;")) (insert str) (fontify-buffer) (let* ((fn-
  (progn (funcall 'c++-mode) (font-lock-mode) (rainbow-delimiters-mode
  (unwind-protect (progn (funcall 'c++-mode) (font-lock-mode) (rainbow
  (save-current-buffer (set-buffer temp-buffer) (unwind-protect (progn
  (let ((temp-buffer (generate-new-buffer " *temp*" t))) (save-current
  (lambda nil (let ((temp-buffer (generate-new-buffer " *temp*" t))) (
  ert--run-test-internal(#s(ert--test-execution-info :test #s(ert-test
  ert-run-test(#s(ert-test :name highlights-all-delimiters :documentat
  ert-run-or-rerun-test(#s(ert--stats :selector t :tests ... :test-map
  ert-run-tests(t #f(compiled-function (event-type &rest event-args) #
  ert-run-tests-batch(nil)
  ert-run-tests-batch-and-exit()
  command-line-1(("-l" "rainbow-delimiters-test.el" "-f" "ert-run-test
  command-line()
  normal-top-level()
Test highlights-all-delimiters condition:
    (ert-test-failed
     ((should
       (ert-equal-including-properties
	(progn ... ...)
	#("foo<int> x;" 0 3 ... 3 4 ... 4 7 ... 7 8 ... 9 10 ...)))
      :form
      (ert-equal-including-properties
       #("foo<int> x;" 0 3
	 (face font-lock-type-face)
	 3 4
	 (face ... c-<>-c-types-set t)
	 4 7
	 (face font-lock-type-face)
	 7 8
	 (face ...)
	 9 10
	 (face font-lock-variable-name-face))
       #("foo<int> x;" 0 3
	 (face font-lock-type-face)
	 3 4
	 (face ...)
	 4 7
	 (face font-lock-type-face)
	 7 8
	 (face ...)
	 9 10
	 (face font-lock-variable-name-face)))
      :value nil :explanation
      (char 3 "<"
	    (different-properties-for-key c-<>-c-types-set
					  (different-atoms t nil))
	    context-before "foo" context-after "int> x;")))
   FAILED  14/24  highlights-all-delimiters (0.032858 sec) at rainbow-delimiters-test.el:144
   passed  15/24  highlights-already-highlighted (0.003059 sec)
   passed  16/24  highlights-matching-braces (0.000096 sec)
   passed  17/24  highlights-matching-brackets (0.000102 sec)
   passed  18/24  highlights-matching-parens (0.000083 sec)
   passed  19/24  highlights-mismatched (0.000205 sec)
   passed  20/24  highlights-mixed-matching-delimiters (0.000105 sec)
   passed  21/24  highlights-nested-matching-braces (0.000159 sec)
   passed  22/24  highlights-nested-matching-brackets (0.000159 sec)
   passed  23/24  highlights-nested-matching-parens (0.000128 sec)
   passed  24/24  highlights-unmatched (0.000156 sec)

Ran 24 tests, 23 results as expected, 1 unexpected (2023-08-29 02:40:33+0000, 0.109225 sec)

1 unexpected results:
   FAILED  highlights-all-delimiters
```